### PR TITLE
Instructions to run Mednafen did not work as documented in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PockulusCHIP
 
 
-1. Print the PockulusC.H.I.P. VR Bezel and eyepiece. 
+1. Print the PockulusC.H.I.P. VR Bezel and eyepiece.
 2. Attach to PocketC.H.I.P. and install the VR software.
 3. sudo apt-get update && sudo apt-get install mednafen
-4. mednafen -video.driver sdl -vb.default_color 0xff0000 -vb.3dmode sidebyside -vb.xres 470 -vb.yres 272 NAME_OF_ROM
+4. mednafen -video.fs 1 -video.driver sdl -vb.default_color 0xff0000 -vb.3dmode sidebyside -vb.xres 470 -vb.yres 272 NAME_OF_ROM
 
-Designed by Thomas Deckert 
+Designed by Thomas Deckert
 
 ---
-These files are Creative Commons Attribution-NonCommercial-ShareAlike 4.0 see LICENSE for details. 
+These files are Creative Commons Attribution-NonCommercial-ShareAlike 4.0 see LICENSE for details.


### PR DESCRIPTION
The readme file contained an error in the last command to properly run the program in the pocket chip which did not properly display video when following the the instructions as directed. The command is missing the parameter `-video.fs 1` My assumption is that this issue might have happened after the command was featured in the Pockulus Chip blog article, which did feature the command with this parameter, but was missing a space between it and the next parameter which also did not properly run the program. I suggest that both typos be corrected in both places, as I'm sure it has caused people considerable frustration.

I have successfully tested the command in my branch to work properly on my Pocket Chip.